### PR TITLE
Add tidal initialisation script automatically run when ghci starts up

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,13 @@
+import Sound.Tidal.Context
+d1 <- dirtStream
+d2 <- dirtStream
+d3 <- dirtStream
+d4 <- dirtStream
+d5 <- dirtStream
+d6 <- dirtStream
+d7 <- dirtStream
+d8 <- dirtStream
+d9 <- dirtStream
+d10 <- dirtStream
+(cps, getNow) <- bpsUtils
+


### PR DESCRIPTION
So that tidal works without needing special initialisation by extramuros itself
